### PR TITLE
Fix: last_executed_query() when params is a mapping of values

### DIFF
--- a/clickhouse_backend/backend/operations.py
+++ b/clickhouse_backend/backend/operations.py
@@ -385,10 +385,9 @@ class DatabaseOperations(BaseDatabaseOperations):
             if insert_pattern.match(sql):
                 return "%s %s" % (sql, ", ".join(map(str, params)))
             else:
-                try:
-                    return sql % tuple(params)
-                except TypeError:
-                    return sql % params
+                if not isinstance(params, (tuple, dict)):
+                    params = tuple(params)
+                return sql % params
         return sql
 
     def settings_sql(self, **kwargs):

--- a/clickhouse_backend/backend/operations.py
+++ b/clickhouse_backend/backend/operations.py
@@ -385,7 +385,10 @@ class DatabaseOperations(BaseDatabaseOperations):
             if insert_pattern.match(sql):
                 return "%s %s" % (sql, ", ".join(map(str, params)))
             else:
-                return sql % tuple(params)
+                try:
+                    return sql % tuple(params)
+                except TypeError:
+                    return sql % params
         return sql
 
     def settings_sql(self, **kwargs):

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -132,7 +132,7 @@ class LastExecutedQueryTest(TestCase):
     @skipUnlessDBFeature("supports_paramstyle_pyformat")
     def test_last_executed_query_params_dict(self):
         square_opts = Square._meta
-        sql = "SELECT %s, %s FROM %s WHERE %s =" %  (
+        sql = "SELECT %s, %s FROM %s WHERE %s =" % (
             connection.ops.quote_name(square_opts.get_field("root").column),
             connection.ops.quote_name(square_opts.get_field("square").column),
             connection.introspection.identifier_converter(square_opts.db_table),


### PR DESCRIPTION
As reported in #92, `last_executed_query()` fails when parametrization uses a mapping of values. 

A [test](https://github.com/jayvynl/django-clickhouse-backend/pull/93/commits/5d94d1a6b3a98b32863c6a74cf1cab7e0288104e) has been created and it reproduces the issue.