### PR TITLE
Fix deprecated index_together for django 5.1

### DIFF
--- a/clickhouse_backend/backend/schema.py
+++ b/clickhouse_backend/backend/schema.py
@@ -213,7 +213,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         )
         if (
             any(field.db_index for field in model._meta.local_fields)
-            or model._meta.index_together
+            or getattr(model._meta, "index_together", None)
         ):
             warnings.warn(msg)
 


### PR DESCRIPTION
Django 5.1 removes `index_together` from `Model.Meta` and there exist a condition in `schema.py` that uses `index_together`. This pr aims to fix the deprecation and keep it compatible with prior django versions as well