### PR TITLE
fix: pass DSN to clickhouse-client if configured

### DIFF
--- a/clickhouse_backend/backend/client.py
+++ b/clickhouse_backend/backend/client.py
@@ -17,19 +17,23 @@ class DatabaseClient(BaseDatabaseClient):
         user = settings_dict.get("USER")
         passwd = settings_dict.get("PASSWORD")
         secure = options.get("secure")
+        dsn = options.get("dsn")
 
-        if host:
-            args += ["-h", host]
-        if port:
-            args += ["--port", str(port)]
-        if user:
-            args += ["-u", user]
-        if passwd:
-            args += ["--password", passwd]
-        if dbname:
-            args += ["-d", dbname]
-        if secure:
-            args += ["--secure"]
+        if dsn:
+            args += [dsn]
+        else:
+            if host:
+                args += ["-h", host]
+            if port:
+                args += ["--port", str(port)]
+            if user:
+                args += ["-u", user]
+            if passwd:
+                args += ["--password", passwd]
+            if dbname:
+                args += ["-d", dbname]
+            if secure:
+                args += ["--secure"]
         args.extend(parameters)
         return args, None
 


### PR DESCRIPTION
Pass the DSN to `clickhouse-client` if configured, rather than relying on individual config values.
