### PR TITLE
POL-8512: Fix handling of Generic Ip fields

### DIFF
--- a/clickhouse_backend/backend/operations.py
+++ b/clickhouse_backend/backend/operations.py
@@ -217,7 +217,7 @@ class DatabaseOperations(BaseDatabaseOperations):
             elif internal_type == "IPv6Field":
                 lookup = "IPv6NumToString(%s)"
             elif internal_type == "GenericIPAddressField":
-                lookup = "replaceRegexpOne(IPv6NumToString(%s), '^::ffff:', '')"
+                lookup = "%s"
             elif internal_type in ("EnumField", "Enum8Field", "Enum16Field"):
                 lookup = "toString(%s)"
             else:


### PR DESCRIPTION
Since we are storing this as strings, not CH ip field, we dont need to do any conversion or casting