### PR TITLE
For a given query execution, allow data to be returned in columnar format and deserialized to numpy objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.4.0
+
+- feat: #119 Allow query results returned in columns and deserialized to `numpy` objects
+
 ### 1.3.2
 
 - feat(aggragation-function): add anyLast function.

--- a/clickhouse_backend/driver/connection.py
+++ b/clickhouse_backend/driver/connection.py
@@ -114,7 +114,7 @@ class Cursor(cursor.Cursor):
             self._client.progress_query_result_cls = ProgressQueryResult
 
     @contextmanager
-    def set_query_args(
+    def set_query_execution_args(
         self, columnar: T.Optional[bool] = None, use_numpy: T.Optional[bool] = None
     ):
         original_use_numpy = self.use_numpy

--- a/clickhouse_backend/driver/connection.py
+++ b/clickhouse_backend/driver/connection.py
@@ -73,7 +73,6 @@ connection.Connection.send_query = send_query
 
 
 class Cursor(cursor.Cursor):
-    
     # Whether to return data in columnar format. For backwards-compatibility,
     # let's default to None.
     columnar = None

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -578,7 +578,7 @@ class ColumnarTestCase(TransactionTestCase):
             LIMIT 10
         """
         with connections["s2r1"].cursor() as cursorWrapper:
-            with cursorWrapper.cursor.set_query_args(columnar=True) as cursor:
+            with cursorWrapper.cursor.set_query_execution_args(columnar=True) as cursor:
                 cursor.execute(sql)
                 self.assertEqual(
                     cursor.fetchall(),
@@ -630,7 +630,7 @@ class ColumnarTestCase(TransactionTestCase):
         import numpy as np
 
         with connections["s2r1"].cursor() as cursorWrapper:
-            with cursorWrapper.cursor.set_query_args(
+            with cursorWrapper.cursor.set_query_execution_args(
                 columnar=True, use_numpy=True
             ) as cursor:
                 cursor.execute(sql)
@@ -701,7 +701,7 @@ class ColumnarTestCase(TransactionTestCase):
         import numpy as np
 
         with connections["s2r1"].cursor() as cursorWrapper:
-            with cursorWrapper.cursor.set_query_args(
+            with cursorWrapper.cursor.set_query_execution_args(
                 columnar=False, use_numpy=True
             ) as cursor:
                 cursor.execute(sql)

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     django5.1: Django>=5.1,<5.2
     coverage
 commands =
-    pip install numpy
+    pip install pandas
     # Use local clickhouse_backend package so that coverage works properly.
     pip install -e .
     coverage run tests/runtests.py --debug-sql {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     django5.1: Django>=5.1,<5.2
     coverage
 commands =
+    pip install numpy
     # Use local clickhouse_backend package so that coverage works properly.
     pip install -e .
     coverage run tests/runtests.py --debug-sql {posargs}


### PR DESCRIPTION
This PR will allow SQL query results to be returned in columns and to be deserialized to numpy objects, without affecting other queries that could run in the system (e.g. Database introspection queries, INSERT queries, etc.)

Relates:

- #119 