### PR TITLE
Fix for simultaneous queries issue when iterating 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 1.5.0
-
+- feat: #133: Fix simultaneous queries error when iteration is interrupted
 - feat: #130: Add `distributed_migrations` database setting to support distributed migration queries.
 - feat: #129: Add `toYearWeek` datetime functionality
 

--- a/clickhouse_backend/driver/pool.py
+++ b/clickhouse_backend/driver/pool.py
@@ -105,6 +105,11 @@ class ClickhousePool:
                     raise InterfaceError("trying to put unkeyed client")
             if len(self._pool) < self.connections_min and not close:
                 # TODO: verify connection still valid
+
+                # If the connection is currently executing a query, it shouldn't be reused.
+                # Explicitly disconnect it instead.
+                if client.connection.is_query_executing:
+                    client.disconnect()
                 if client.connection.connected:
                     self._pool.append(client)
             else:

--- a/tests/backends/clickhouse/test_driver.py
+++ b/tests/backends/clickhouse/test_driver.py
@@ -30,6 +30,11 @@ class IterationTests(TestCase):
         )
 
     def test_connection_not_reused_when_iteration_interrupted(self):
+        """
+        This test demonstrates that if a queryset is iterated over and the
+        iteration is interrupted (e.g. via a break statement), the connection
+        used for that iteration is disconnected and not returned to the pool.
+        """
         pool = connection.connection.pool
 
         connection_count_before = len(pool._pool)

--- a/tests/backends/clickhouse/test_driver.py
+++ b/tests/backends/clickhouse/test_driver.py
@@ -1,6 +1,14 @@
+from clickhouse_driver.dbapi.errors import (
+    OperationalError as ch_driver_OperationalError,
+)
+from clickhouse_driver.errors import PartiallyConsumedQueryError
+from django.db import connection
+from django.db.utils import OperationalError as django_OperationalError
 from django.test import TestCase
 
 from clickhouse_backend.driver import connect
+
+from .. import models
 
 
 class Tests(TestCase):
@@ -9,3 +17,58 @@ class Tests(TestCase):
         assert conn.pool.connections_min == 2
         assert conn.pool.connections_max == 4
         assert len(conn.pool._pool) == 2
+
+
+class IterationTests(TestCase):
+    """
+    Testing connection behaviour when iterating over queryset is interrupted.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.a1, cls.a2, cls.a3 = models.Author.objects.bulk_create(
+            [
+                models.Author(name="a1"),
+                models.Author(name="a2"),
+                models.Author(name="a3"),
+            ]
+        )
+
+    def test_connection_unusable_when_iteration_interrupted(self):
+        """
+        This test demonstrates that if a queryset is iterated over and the iteration
+        is interrupted (e.g. via a break statement), the connection used for that
+        iteration is not cleaned up and is left in a broken state. Any subsequent
+        queries using that connection will fail.
+        """
+        pool = connection.connection.pool
+        connection_count_before = len(pool._pool)
+
+        assert connection_count_before == 1
+
+        # Asserts most recent exception is Django OperationalError
+        with self.assertRaises(django_OperationalError) as ex_context:
+            # Get queryset
+            authors = models.Author.objects.all()
+            # Access iterator, but break after first item
+            for author in authors.iterator(1):
+                author = author.name
+                break
+
+            # Assert connection pool size is unchanged despite broken connection
+            connection_count_after_iterator = len(pool._pool)
+            assert connection_count_after_iterator == 1
+
+            # Try to access queryset again, which won't work via same connection
+            author = authors.get(id=self.a1.id)
+
+        # Caused by ch driver driver Operational error
+        self.assertIsInstance(
+            ex_context.exception.__cause__, ch_driver_OperationalError
+        )
+
+        # ...The context of which is a PartiallyConsumedQueryError
+        # https://github.com/mymarilyn/clickhouse-driver/blob/master/clickhouse_driver/connection.py#L801
+        self.assertIsInstance(
+            ex_context.exception.__cause__.__context__, PartiallyConsumedQueryError
+        )


### PR DESCRIPTION
If iterating over a Django queryset and iteration is broken for any reason, the connection will stay alive and be re-added to the connection pool. Upon issuing another query to Clickhouse, a `PartiallyConsumedQueryError` is thrown. This is raised [here](https://github.com/mymarilyn/clickhouse-driver/blob/8a4e7c5b99b532df2b015651d893a6f36288a22c/clickhouse_driver/connection.py#L801) in the Clickhouse driver. 

Commit `562a7e5b1948b1483386c7239c5d480e27d389cd `  demonstrates the problematic behaviour [here](https://github.com/jayvynl/django-clickhouse-backend/pull/133/commits/562a7e5b1948b1483386c7239c5d480e27d389cd). 

This PR adds a check to the connection for `is_query_executing`. If this is true, the connection is not re-added to the pool and is instead disconnected.