### PR TITLE
Support for SAMPLE BY in schema creation, SAMPLE clause, and toStartOfDay datetime function 

### DIFF
--- a/clickhouse_backend/backend/schema.py
+++ b/clickhouse_backend/backend/schema.py
@@ -254,6 +254,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             order_by = engine.order_by
             partition_by = engine.partition_by
             primary_key = engine.primary_key
+            sample_by = engine.sample_by
 
             if order_by is not None:
                 yield "ORDER BY (%s)" % self._get_expression(model, *order_by)
@@ -261,6 +262,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 yield "PARTITION BY (%s)" % self._get_expression(model, *partition_by)
             if primary_key is not None:
                 yield "PRIMARY KEY (%s)" % self._get_expression(model, *primary_key)
+            if sample_by is not None:
+                yield "SAMPLE BY (%s)" % self._get_expression(model, *sample_by)
         if engine.settings:
             result = []
             for setting, value in engine.settings.items():

--- a/clickhouse_backend/models/engines.py
+++ b/clickhouse_backend/models/engines.py
@@ -128,6 +128,7 @@ class BaseMergeTree(Engine):
         order_by=None,
         partition_by=None,
         primary_key=None,
+        sample_by=None,
         **settings,
     ):
         assert (
@@ -136,8 +137,9 @@ class BaseMergeTree(Engine):
         self.order_by = order_by
         self.primary_key = primary_key
         self.partition_by = partition_by
+        self.sample_by = sample_by
 
-        for key in ["order_by", "primary_key", "partition_by"]:
+        for key in ["order_by", "primary_key", "partition_by", "sample_by"]:
             value = getattr(self, key)
             if value is not None:
                 if isinstance(value, str) or not isinstance(value, Iterable):

--- a/clickhouse_backend/models/functions/datetime.py
+++ b/clickhouse_backend/models/functions/datetime.py
@@ -11,6 +11,7 @@ __all__ = [
     "toStartOfTenMinutes",
     "toStartOfFifteenMinutes",
     "toStartOfHour",
+    "toStartOfDay",
     "toYYYYMM",
     "toYYYYMMDD",
     "toYYYYMMDDhhmmss",
@@ -77,6 +78,10 @@ class toStartOfFifteenMinutes(toStartOfMinute):
 
 
 class toStartOfHour(toStartOfMinute):
+    pass
+
+
+class toStartOfDay(toStartOfMinute):
     pass
 
 

--- a/clickhouse_backend/models/query.py
+++ b/clickhouse_backend/models/query.py
@@ -31,6 +31,11 @@ class QuerySet(query.QuerySet):
         clone._query.add_prewhere(Q(*args, **kwargs))
         return clone
 
+    def sample(self, sample_fraction, sample_offset=None):
+        clone = self._chain()
+        clone._query.add_sample(sample_fraction, sample_offset)
+        return clone
+
     def datetimes(self, field_name, kind, order="ASC", tzinfo=None):
         """
         Return a list of datetime objects representing all available

--- a/clickhouse_backend/models/sql/compiler.py
+++ b/clickhouse_backend/models/sql/compiler.py
@@ -122,6 +122,8 @@ class SQLCompiler(ClickhouseMixin, compiler.SQLCompiler):
         refcounts_before = self.query.alias_refcount.copy()
         try:
             combinator = self.query.combinator
+            sample_fraction = self.query.sample_fraction
+            sample_offset = self.query.sample_offset
             if compat.dj_ge42:
                 extra_select, order_by, group_by = self.pre_sql_setup(
                     with_col_aliases=with_col_aliases or bool(combinator),
@@ -202,6 +204,13 @@ class SQLCompiler(ClickhouseMixin, compiler.SQLCompiler):
                 if from_:
                     result += ["FROM", *from_]
                 params.extend(f_params)
+
+                if sample_fraction:
+                    if sample_offset:
+                        sample_sql = "SAMPLE %s OFFSET %s" % (sample_fraction, sample_offset)
+                    else:
+                        sample_sql = "SAMPLE %s" % sample_fraction
+                    result.append(sample_sql)
 
                 if prewhere:
                     result.append("PREWHERE %s" % prewhere)

--- a/clickhouse_backend/models/sql/query.py
+++ b/clickhouse_backend/models/sql/query.py
@@ -19,6 +19,8 @@ class Query(query.Query):
             super().__init__(model, where, alias_cols)
         self.setting_info = {}
         self.prewhere = query.WhereNode()
+        self.sample_fraction = None
+        self.sample_offset = None
 
     def sql_with_params(self):
         """Choose the right db when database router is used."""
@@ -28,6 +30,8 @@ class Query(query.Query):
         obj = super().clone()
         obj.setting_info = self.setting_info.copy()
         obj.prewhere = self.prewhere.clone()
+        obj.sample_fraction = self.sample_fraction
+        obj.sample_offset = self.sample_offset
         return obj
 
     def explain(self, using, format=None, type=None, **settings):
@@ -35,6 +39,10 @@ class Query(query.Query):
         q.explain_info = ExplainInfo(format, type, settings)
         compiler = q.get_compiler(using=using)
         return "\n".join(compiler.explain_query())
+
+    def add_sample(self, sample_fraction, sample_offset):
+        self.sample_fraction = sample_fraction
+        self.sample_offset = sample_offset
 
     def add_prewhere(self, q_object):
         """


### PR DESCRIPTION
Hi all, just quickly hacked in support for SAMPLE BY support when creating models and added a missing datetime function. I also implemented support for the [SAMPLE clause](https://clickhouse.com/docs/sql-reference/statements/select/sample).

This adds a new "sample_by" parameter to the constructor of BaseMergeTree, which can be used to enable sampling on your table.

```
from clickhouse_backend import models
from clickhouse_backend.models.functions.hashes import farmFingerprint64
from clickhouse_backend.models.functions.datetime import toStartOfDay

class DemoLog(models.ClickhouseModel):
    timestamp = models.DateTimeField(default=timezone.now)
    ip = models.GenericIPAddressField(default="::")

    class Meta:
        engine = models.MergeTree(
            primary_key=("timestamp", toStartOfDay("timestamp"), farmFingerprint64("ip")),
            order_by=("timestamp", toStartOfDay("timestamp"), farmFingerprint64("ip")),
            partition_by=toStartOfMonth("timestamp"),
            sample_by=(farmFingerprint64("ip"),),
            index_granularity=8192,
        )
```

You can query using the SAMPLE clause using the new `.sample` function like so:

```
session_count_estimate = DemoLog.objects.filter(timestamp__gte=time_start, timestamp__lte=time_end).sample(0.1).aggregate(session_count=Count('id') * 10
```

The new sample function takes two parameters: 

```
    def sample(self, sample_fraction, sample_offset=None):
```

which generates either a `SAMPLE k` or `SAMPLE k OFFSET m` clause [as per the Clickhouse docs on SAMPLE](https://clickhouse.com/docs/sql-reference/statements/select/sample).

I didn't include unit tests because I'm too lazy to spin up all the docker stuff and I'm in a hurry to get some bare minimum thing here working. I'm hoping this is PR is useful for others and could be useful for the project. Thanks!