### PR TITLE
Fix/connection pool validation

### DIFF
--- a/clickhouse_backend/driver/pool.py
+++ b/clickhouse_backend/driver/pool.py
@@ -1,4 +1,5 @@
 import threading
+import logging
 from contextlib import contextmanager
 from typing import Generator, Union
 
@@ -6,6 +7,7 @@ from clickhouse_driver.dbapi.errors import InterfaceError
 
 from .client import Client
 
+logger = logging.getLogger(__name__)
 
 class ClickhousePool:
     """A modified version of clickhouse_pool.ChPool
@@ -110,8 +112,10 @@ class ClickhousePool:
                 # Explicitly disconnect it instead.
                 if client.connection.is_query_executing:
                     client.disconnect()
-                if client.connection.connected:
+                if client.connection.connected and client.connection.ping():
                     self._pool.append(client)
+                else:
+                    client.disconnect()
             else:
                 client.disconnect()
 
@@ -136,8 +140,8 @@ class ClickhousePool:
                 try:
                     client.disconnect()
                 # TODO: handle problems with disconnect
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.error("Error occurred while disconnecting client: %s", e)
             self.closed = True
         finally:
             self._lock.release()

--- a/tests/backends/clickhouse/test_driver.py
+++ b/tests/backends/clickhouse/test_driver.py
@@ -1,7 +1,10 @@
+from unittest.mock import MagicMock, PropertyMock, patch
+
 from django.db import connection
 from django.test import TestCase
 
 from clickhouse_backend.driver import connect
+from clickhouse_backend.driver.pool import ClickhousePool
 
 from .. import models
 
@@ -12,6 +15,98 @@ class Tests(TestCase):
         assert conn.pool.connections_min == 2
         assert conn.pool.connections_max == 4
         assert len(conn.pool._pool) == 2
+
+
+class PoolConnectionValidationTests(TestCase):
+    """Tests for connection ping validation when returning connections to pool."""
+
+    def _make_pool_and_client(self):
+        """Helper to create a pool and pull a client from it."""
+        conn = connect(host="localhost", connections_min=1, connections_max=2)
+        pool = conn.pool
+        client = pool.pull()
+        return pool, client
+
+    def test_push_valid_connection_returns_to_pool(self):
+        """A connection that passes ping should be returned to the pool."""
+        pool, client = self._make_pool_and_client()
+        pool_size_before = len(pool._pool)
+
+        pool.push(client=client)
+
+        self.assertEqual(len(pool._pool), pool_size_before + 1)
+        pool.cleanup()
+
+    def test_push_dead_connection_not_returned_to_pool(self):
+        """A connection that fails ping should be disconnected, not pooled."""
+        pool, client = self._make_pool_and_client()
+        pool._pool.clear()  # empty pool so push will try to add it back
+
+        # Simulate a dead connection: ping returns False
+        original_ping = client.connection.ping
+        client.connection.ping = MagicMock(return_value=False)
+
+        pool.push(client=client)
+
+        # Dead connection should NOT be in pool
+        self.assertEqual(len(pool._pool), 0)
+
+        client.connection.ping = original_ping
+        pool.cleanup()
+
+    def test_push_disconnected_connection_not_returned_to_pool(self):
+        """A connection with connected=False should not be returned to pool."""
+        pool, client = self._make_pool_and_client()
+        pool._pool.clear()
+
+        # Disconnect the client so connected=False
+        client.disconnect()
+
+        pool.push(client=client)
+
+        # Disconnected connection should NOT be in pool
+        self.assertEqual(len(pool._pool), 0)
+        pool.cleanup()
+
+
+class PoolCleanupLoggingTests(TestCase):
+    """Tests for disconnect error logging during pool cleanup."""
+
+    def test_cleanup_logs_disconnect_errors(self):
+        """Errors during disconnect in cleanup() should be logged, not silenced."""
+        conn = connect(host="localhost", connections_min=1, connections_max=2)
+        pool = conn.pool
+
+        # Make disconnect raise an exception
+        for client in pool._pool:
+            client.disconnect = MagicMock(
+                side_effect=Exception("mock disconnect error")
+            )
+
+        with self.assertLogs(
+            "clickhouse_backend.driver.pool", level="ERROR"
+        ) as log_output:
+            pool.cleanup()
+
+        # Verify error was logged
+        self.assertTrue(
+            any("mock disconnect error" in msg for msg in log_output.output)
+        )
+
+    def test_cleanup_succeeds_despite_disconnect_errors(self):
+        """Pool should still be marked closed even if disconnect fails."""
+        conn = connect(host="localhost", connections_min=1, connections_max=2)
+        pool = conn.pool
+
+        for client in pool._pool:
+            client.disconnect = MagicMock(
+                side_effect=Exception("mock disconnect error")
+            )
+
+        with self.assertLogs("clickhouse_backend.driver.pool", level="ERROR"):
+            pool.cleanup()
+
+        self.assertTrue(pool.closed)
 
 
 class IterationTests(TestCase):


### PR DESCRIPTION
## Summary
- Add `connection.ping()` validation before returning connections to the pool, preventing stale/dead connections from being reused
- Add error logging for disconnect failures in `cleanup()` instead of silently swallowing exceptions with `pass`

## Problem
1. When a connection is returned to the pool, it only checks the local `connected` flag — this doesn't guarantee the server-side connection is still alive. Stale connections could be reused and cause query failures.
2. During `cleanup()`, disconnect errors are silently ignored (`except: pass`), making it hard to debug connection issues.

## Changes
- **`clickhouse_backend/driver/pool.py`**
  - `push()`: Added `client.connection.ping()` check before returning connection to pool. If ping fails, the connection is disconnected instead of being reused.
  - `cleanup()`: Replaced bare `pass` with `logger.error()` to log disconnect failures.
  - Added `import logging` and module-level logger.

- **`tests/backends/clickhouse/test_driver.py`**
  - Added `PoolConnectionValidationTests` (3 tests): valid ping returns to pool, failed ping discards connection, disconnected client not pooled.
  - Added `PoolCleanupLoggingTests` (2 tests): disconnect errors are logged, pool still closes despite errors.

## Resolves
Addresses the two TODOs in `clickhouse_backend/driver/pool.py`:
- `# TODO: verify connection still valid` (line 107)
- `# TODO: handle problems with disconnect` (line 138)

## Test plan
- [ ] `python tests/runtests.py backends` passes
- [ ] `pre-commit run -a` passes
