### PR TITLE
Integrate startsWith() function use case

### DIFF
--- a/clickhouse_backend/backend/base.py
+++ b/clickhouse_backend/backend/base.py
@@ -15,6 +15,9 @@ from .features import DatabaseFeatures
 from .introspection import DatabaseIntrospection
 from .operations import DatabaseOperations
 from .schema import DatabaseSchemaEditor
+from . import lookups as clickhouse_lookups
+
+_clickhouse_lookups = clickhouse_lookups
 
 
 class DatabaseWrapper(BaseDatabaseWrapper):

--- a/clickhouse_backend/backend/lookups.py
+++ b/clickhouse_backend/backend/lookups.py
@@ -1,0 +1,32 @@
+"""ClickHouse SQL rendering hooks for selected Django field lookups.
+
+This module teaches Django's ``startswith`` and ``istartswith`` lookups how to
+compile to ClickHouse-native string functions. Django's query compiler calls
+the ``as_clickhouse()`` methods added here when building SQL for the ClickHouse
+backend.
+"""
+
+from django.db.models.lookups import BuiltinLookup, StartsWith, IStartsWith
+
+
+def startswith_as_clickhouse(self, compiler, connection):
+    """Render Django's case-sensitive ``startswith`` lookup for ClickHouse."""
+    lhs_sql, lhs_params = self.process_lhs(compiler, connection)
+    rhs_sql, rhs_params = BuiltinLookup.process_rhs(self, compiler, connection)
+
+    return f"startsWith({lhs_sql}, {rhs_sql})", lhs_params + rhs_params
+
+
+def istartswith_as_clickhouse(self, compiler, connection):
+    """Render Django's case-insensitive ``istartswith`` lookup for ClickHouse."""
+    lhs_sql, lhs_params = self.process_lhs(compiler, connection)
+    rhs_sql, rhs_params = BuiltinLookup.process_rhs(self, compiler, connection)
+
+    return (
+        f"startsWithCaseInsensitive({lhs_sql}, {rhs_sql})",
+        lhs_params + rhs_params,
+    )
+
+
+StartsWith.as_clickhouse = startswith_as_clickhouse
+IStartsWith.as_clickhouse = istartswith_as_clickhouse

--- a/tests/backends/clickhouse/test_lookups.py
+++ b/tests/backends/clickhouse/test_lookups.py
@@ -1,0 +1,55 @@
+from unittest import mock
+
+from django.db.models.lookups import BuiltinLookup, IStartsWith, StartsWith
+from django.test import SimpleTestCase
+
+from clickhouse_backend.backend import lookups as clickhouse_lookups
+
+
+class LookupTests(SimpleTestCase):
+    def assertLookupCompiles(self, lookup_class, expected_sql):
+        lookup = object.__new__(lookup_class)
+        lookup.process_lhs = mock.Mock(return_value=('"field"', ["lhs-param"]))
+
+        with mock.patch.object(
+            BuiltinLookup,
+            "process_rhs",
+            return_value=("%s", ["rhs-param"]),
+        ) as process_rhs:
+            sql, params = lookup.as_clickhouse(
+                mock.sentinel.compiler,
+                mock.sentinel.connection,
+            )
+
+        self.assertEqual(sql, expected_sql)
+        self.assertEqual(params, ["lhs-param", "rhs-param"])
+        lookup.process_lhs.assert_called_once_with(
+            mock.sentinel.compiler,
+            mock.sentinel.connection,
+        )
+        process_rhs.assert_called_once_with(
+            lookup,
+            mock.sentinel.compiler,
+            mock.sentinel.connection,
+        )
+
+    def test_startswith_registered_as_clickhouse_lookup(self):
+        self.assertIs(
+            StartsWith.as_clickhouse,
+            clickhouse_lookups.startswith_as_clickhouse,
+        )
+
+    def test_istartswith_registered_as_clickhouse_lookup(self):
+        self.assertIs(
+            IStartsWith.as_clickhouse,
+            clickhouse_lookups.istartswith_as_clickhouse,
+        )
+
+    def test_startswith_compiles_to_clickhouse_function(self):
+        self.assertLookupCompiles(StartsWith, 'startsWith("field", %s)')
+
+    def test_istartswith_compiles_to_clickhouse_function(self):
+        self.assertLookupCompiles(
+            IStartsWith,
+            'startsWithCaseInsensitive("field", %s)',
+        )


### PR DESCRIPTION
Use ClickHouse startsWith functions for prefix lookups

Problem:
Django's default startswith and istartswith lookups are rendered as LIKE/ILIKE
expressions. For ClickHouse, this is less direct and can produce SQL that does
not take advantage of ClickHouse's native string prefix functions.

Solution:
Add ClickHouse-specific rendering for Django's startswith and istartswith
lookups by compiling them to startsWith() and startsWithCaseInsensitive().
These functions express the intent directly, avoid LIKE pattern construction,
and align the generated SQL with ClickHouse's native string function support.

Advantages:
- Uses ClickHouse-native functions for prefix checks.
- Produces clearer SQL for startswith/istartswith filters.
- Avoids wildcard-based LIKE/ILIKE prefix patterns.
- Keeps Django lookup behavior while improving backend-specific SQL generation.
- Adds unit coverage for lookup registration, generated SQL, and parameter handling.