### PR TITLE
Add groupUniqArray to aggregates

### DIFF
--- a/clickhouse_backend/models/aggregates.py
+++ b/clickhouse_backend/models/aggregates.py
@@ -1,7 +1,7 @@
 from django.db.models import aggregates
 from django.db.models.expressions import Star
 
-from clickhouse_backend.models.fields import UInt64Field
+from clickhouse_backend.models.fields import ArrayField, UInt64Field
 
 __all__ = [
     "uniq",
@@ -12,6 +12,7 @@ __all__ = [
     "uniqTheta",
     "anyLast",
     "argMax",
+    "groupUniqArray",
 ]
 
 
@@ -75,3 +76,14 @@ class argMax(Aggregate):
 
     def _resolve_output_field(self):
         return self.get_source_fields()[0]
+
+
+class groupUniqArray(Aggregate):
+    """
+    Collect the distinct non-NULL values of the argument into an array. The order of the resulting array is not guaranteed. 
+    """
+
+    arity = 1
+
+    def _resolve_output_field(self):
+        return ArrayField(base_field=self.get_source_fields()[0])

--- a/tests/aggregates/tests.py
+++ b/tests/aggregates/tests.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 
 from clickhouse_backend.models import (
     anyLast,
+    groupUniqArray,
     uniq,
     uniqCombined,
     uniqCombined64,
@@ -277,3 +278,44 @@ class AggregatesTestCase(TestCase):
         )
 
         self.assertQuerysetEqual(result, self.expected_result_any_last, transform=dict)
+
+    def test_groupUniqArray(self):
+        # Collects the distinct shows each user has watched. Many rows per user
+        # collapse to the unique set; the order of each array is not guaranteed.
+        result = {
+            row["uid"]: set(row["shows"])
+            for row in WatchSeries.objects.values("uid").annotate(
+                shows=groupUniqArray("show")
+            )
+        }
+
+        expected_result = {
+            "alice": {"Game of Thrones", "Bridgerton"},
+            "bob": {"Game of Thrones", "Bridgerton"},
+            "carol": {"Bridgerton"},
+            "dan": {"Bridgerton"},
+            "erin": {"Game of Thrones", "Bridgerton"},
+        }
+
+        self.assertEqual(result, expected_result)
+
+    def test_groupUniqArray_output_field(self):
+        # The output field is an ArrayField, so array transforms such as ``len``
+        # resolve against the annotation.
+        result = (
+            WatchSeries.objects.values("uid")
+            .annotate(shows=groupUniqArray("show"))
+            .annotate(num_shows=F("shows__len"))
+            .values("uid", "num_shows")
+            .order_by("uid")
+        )
+
+        expected_result = [
+            {"uid": "alice", "num_shows": 2},
+            {"uid": "bob", "num_shows": 2},
+            {"uid": "carol", "num_shows": 1},
+            {"uid": "dan", "num_shows": 1},
+            {"uid": "erin", "num_shows": 2},
+        ]
+
+        self.assertQuerysetEqual(result, expected_result, transform=dict)


### PR DESCRIPTION
Added support for the [groupUniqArray](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/groupuniqarray) aggregate.