### PR TITLE
fix(#161): log pool disconnect failures instead of swallowing them

### DIFF
--- a/clickhouse_backend/driver/pool.py
+++ b/clickhouse_backend/driver/pool.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 from contextlib import contextmanager
 from typing import Generator, Union
@@ -5,6 +6,8 @@ from typing import Generator, Union
 from clickhouse_driver.dbapi.errors import InterfaceError
 
 from .client import Client
+
+logger = logging.getLogger(__name__)
 
 
 class ClickhousePool:
@@ -104,7 +107,14 @@ class ClickhousePool:
                 if key is None:
                     raise InterfaceError("trying to put unkeyed client")
             if len(self._pool) < self.connections_min and not close:
-                # TODO: verify connection still valid
+                # Liveness is deliberately not checked here. A pooled connection
+                # can die at any point while it sits idle, so a check on the way
+                # in proves nothing about the state it will be in on the way out.
+                # clickhouse_driver validates on use instead: every query starts
+                # with `Connection.force_connect()`, which pings the server and
+                # reconnects if the connection is gone. Pinging here would add a
+                # round trip to every cursor close, taken while holding the pool
+                # lock, without making anything safer.
 
                 # If the connection is currently executing a query, it shouldn't be reused.
                 # Explicitly disconnect it instead.
@@ -135,9 +145,14 @@ class ClickhousePool:
             for client in self._pool + list(self._used.values()):
                 try:
                     client.disconnect()
-                # TODO: handle problems with disconnect
                 except Exception:
-                    pass
+                    # A failed disconnect must not stop the remaining clients
+                    # from being closed, but it should not vanish either.
+                    logger.warning(
+                        "Error while disconnecting %r on pool cleanup",
+                        client.connection,
+                        exc_info=True,
+                    )
             self.closed = True
         finally:
             self._lock.release()

--- a/tests/backends/clickhouse/test_driver.py
+++ b/tests/backends/clickhouse/test_driver.py
@@ -1,3 +1,6 @@
+import socket
+from unittest import mock
+
 from django.db import connection
 from django.test import TestCase
 
@@ -12,6 +15,53 @@ class Tests(TestCase):
         assert conn.pool.connections_min == 2
         assert conn.pool.connections_max == 4
         assert len(conn.pool._pool) == 2
+
+
+class PoolCleanupTests(TestCase):
+    def test_disconnect_error_is_logged_and_does_not_stop_cleanup(self):
+        """
+        A client that fails to disconnect must not silence the failure, nor
+        prevent the remaining clients from being closed.
+        """
+        pool = connect(host="localhost", connections_min=2, connections_max=4).pool
+        failing, healthy = pool._pool
+        error = OSError("cannot disconnect")
+        failing.disconnect = mock.Mock(side_effect=error)
+        healthy.disconnect = mock.Mock()
+
+        with self.assertLogs("clickhouse_backend.driver.pool", "WARNING") as logs:
+            pool.cleanup()
+
+        assert pool.closed
+        healthy.disconnect.assert_called_once_with()
+        (record,) = logs.records
+        # Rendering the message must not raise for a client that never
+        # connected, otherwise it would hide the error being reported.
+        assert repr(failing.connection) in record.getMessage()
+        assert record.exc_info[1] is error
+
+
+class ConnectionRecoveryTests(TestCase):
+    def test_connection_that_died_while_pooled_is_recovered_on_use(self):
+        """
+        A pooled connection can be dropped by the server at any point while it
+        sits idle, which is why push() does not check liveness on the way in.
+        Recovery happens on use: clickhouse_driver pings and reconnects when a
+        query is issued.
+        """
+        with connection.cursor() as cursor:
+            cursor.execute("select 1")
+            assert cursor.fetchall() == [(1,)]
+
+        (client,) = connection.connection.pool._pool
+        # Mimic the server hanging up on an idle pooled connection.
+        client.connection.socket.shutdown(socket.SHUT_RDWR)
+        # The connection is dead, but its own flag does not know that yet.
+        assert client.connection.connected
+
+        with connection.cursor() as cursor:
+            cursor.execute("select 2")
+            assert cursor.fetchall() == [(2,)]
 
 
 class IterationTests(TestCase):


### PR DESCRIPTION
Replaces #161, which is closed in favour of this PR.

#161 set out to resolve the two `TODO`s in `clickhouse_backend/driver/pool.py`. One of them is worth resolving; the other one is a `TODO` that should not be implemented, and #161's implementation of it was a regression. Details below, since the reasoning is the point of the PR.

## `# TODO: handle problems with disconnect` — fixed

`cleanup()` dropped every exception from `client.disconnect()` on the floor, so a client that failed to close left no trace at all. It is now logged at warning level with the traceback, and the loop still closes the remaining clients.

The connection is identified with `%r` rather than `get_description()`: `Connection.get_description()` reads `self.host`, which only exists once the connection has picked a host from `self.hosts`, so it raises `AttributeError` on a client that never connected — the log call would then mask the very error it is reporting. `Connection.__repr__()` handles the unconnected case and masks the password. There is a test for that.

## `# TODO: verify connection still valid` — replaced by a comment explaining why not

#161 added `client.connection.ping()` to `push()` before returning a client to the pool. Checked against the cluster in `compose.yaml`:

- **The premise does not hold.** `clickhouse_driver` already validates on use. Every query goes through `Client.establish_connection()` → `Connection.force_connect()` (`connection.py:274`), which pings and reconnects when the connection is gone. A connection whose peer has hung up serves the next query fine, transparently.
- **`push()` is the wrong side of the pool anyway.** A pooled connection dies while it is *idle*, so a check on the way in says nothing about the state it will be in on the way out. Killing a connection *after* `push()` — the case that actually happens in production — is unaffected by the check, and still recovers.
- **It costs a round trip per query.** `Cursor.close()` calls `push()`, so this is one extra ping per cursor, ~260µs against a local server, taken while holding the pool's global lock — so it serialises every `pull()`/`push()` in every thread behind a network round trip.
- **It can leak a pool slot.** `Connection.ping()` returns `False` for socket errors, but re-raises `errors.Error` (`connection.py:593`), e.g. `UnexpectedPacketFromServerError` when there is leftover data on the socket. That exception escapes `push()` before the `del self._used[key]` / `del self._rused[...]` bookkeeping, so the slot is never released. Reproduced: after one such `push()` the key stays in `_used`, and the pool then dies with `InterfaceError: too many connections`. Pre-change, `push()` cannot raise for a bad connection.

So the `TODO` is removed and replaced with a comment recording why there is nothing to do, and a test pins the behaviour it relies on: a connection killed while sitting in the pool is recovered on next use.

For completeness, #161 did not pass as submitted — `test_push_valid_connection_returned_to_pool` fails with `0 != 1`, because `pool.pull()` hands back a `Client` that has not connected yet, so `connection.connected` is `False` and the client is not pooled regardless of ping. Two of its other three pool tests pass without the change, exercising only the pre-existing `connected` check. `ruff`/`flake8` also fail on it (`E302`, three `F401`s).

## Testing

`python tests/runtests.py backends` — 121 tests, OK, sequentially and at `--parallel=4`. `ruff check`, `ruff format` and `flake8` are clean. The logging test was verified to fail when `cleanup()` is reverted to `except Exception: pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
