### PR TITLE
fix: drop the obsolete Connection.send_query monkey patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - fix: `QuerySet.union(all=True)` generated `UNION ALL ALL`, which ClickHouse rejects as a syntax error.
 - fix: #137 two `EXPLAIN` problems reported by @Azmisov: `QUERY TREE` was not an allowed type, and `QuerySet.explain(format=...)` rejected every output format whose ClickHouse spelling is not all upper case, such as `TabSeparated`.
 - depends: #172 update clickhouse-driver to 0.2.11 on python 3.9 and later, reported by @khvn26. Python 3.7 and 3.8 stay on 0.2.9.
+- fix: drop the `clickhouse_driver.connection.Connection.send_query` monkey patch added for #14. clickhouse-driver has guarded that code with `server_side_params` itself since 0.2.7, so the patch no longer changed anything for this backend, while still replacing upstream's server side parameter escaping process wide — costing any code that uses clickhouse-driver directly the list and tuple escaping fix in 0.2.11. `clickhouse_backend.driver.escape.escape_param()` and `escape_params()` lose their now unreachable `for_server` argument.
 - fix: #167 test database cloning skipped migrations entirely for a database whose `TEST` settings set `managed` to `False`. Such an alias must not run `CREATE DATABASE` for a clone, because the managed alias already created it `ON CLUSTER`, but it does have to migrate: tables that are not `ON CLUSTER` only exist on the node the migration ran against. Clones were therefore missing every local table, such as `django_content_type`, on the unmanaged alias' node, which broke `manage.py test --parallel` against a cluster.
 
 ### 1.6.0

--- a/clickhouse_backend/driver/connection.py
+++ b/clickhouse_backend/driver/connection.py
@@ -2,74 +2,17 @@ import re
 import typing as T
 from contextlib import contextmanager
 
-from clickhouse_driver import connection
 from clickhouse_driver.dbapi import connection as dbapi_connection
 from clickhouse_driver.dbapi import cursor, errors
 from clickhouse_driver.result import IterQueryResult, ProgressQueryResult, QueryResult
 from django.conf import settings
 
-from .escape import escape_params
 from .pool import ClickhousePool
 
 name_regex = r'"(?:[^"]|\\.)+"'
 value_regex = r"(')?(?(1)(?:[^']|\\.)+|\S+)(?(1)'|)"
 name_value_regex = f"{name_regex} = {value_regex}"
 update_pattern = re.compile(f"^ALTER TABLE ({name_regex}) UPDATE ")
-
-
-def send_query(self, query, query_id=None, params=None):
-    if not self.connected:
-        self.connect()
-
-    connection.write_varint(connection.ClientPacketTypes.QUERY, self.fout)
-
-    connection.write_binary_str(query_id or "", self.fout)
-
-    revision = self.server_info.used_revision
-    if revision >= connection.defines.DBMS_MIN_REVISION_WITH_CLIENT_INFO:
-        client_info = connection.ClientInfo(
-            self.client_name, self.context, client_revision=self.client_revision
-        )
-        client_info.query_kind = connection.ClientInfo.QueryKind.INITIAL_QUERY
-
-        client_info.write(revision, self.fout)
-
-    settings_as_strings = (
-        revision
-        >= connection.defines.DBMS_MIN_REVISION_WITH_SETTINGS_SERIALIZED_AS_STRINGS
-    )
-    settings_flags = 0
-    if self.settings_is_important:
-        settings_flags |= connection.SettingsFlags.IMPORTANT
-    connection.write_settings(
-        self.context.settings, self.fout, settings_as_strings, settings_flags
-    )
-
-    if revision >= connection.defines.DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET:
-        connection.write_binary_str("", self.fout)
-
-    connection.write_varint(connection.QueryProcessingStage.COMPLETE, self.fout)
-    connection.write_varint(self.compression, self.fout)
-
-    connection.write_binary_str(query, self.fout)
-
-    if revision >= connection.defines.DBMS_MIN_PROTOCOL_VERSION_WITH_PARAMETERS:
-        if self.context.client_settings["server_side_params"]:
-            # Always settings_as_strings = True
-            escaped = escape_params(params or {}, self.context, for_server=True)
-        else:
-            escaped = {}
-        connection.write_settings(
-            escaped, self.fout, True, connection.SettingsFlags.CUSTOM
-        )
-
-    connection.logger.debug("Query: %s", query)
-
-    self.fout.flush()
-
-
-# Monkey patch to resolve https://github.com/jayvynl/django-clickhouse-backend/issues/14
-connection.Connection.send_query = send_query
 
 
 class Cursor(cursor.Cursor):

--- a/clickhouse_backend/driver/escape.py
+++ b/clickhouse_backend/driver/escape.py
@@ -38,8 +38,7 @@ def escape_binary(item: bytes, context):
     return b2s[1:]
 
 
-@escape.maybe_enquote_for_server
-def escape_param(item, context, for_server=False):
+def escape_param(item, context):
     if item is None:
         return "NULL"
 
@@ -53,29 +52,21 @@ def escape_param(item, context, for_server=False):
         return "'%s'" % item.strftime("%H:%M:%S")
 
     elif isinstance(item, str):
-        # We need double escaping for server-side parameters.
-        if for_server:
-            item = "".join(escape.escape_chars_map.get(c, c) for c in item)
         return "'%s'" % "".join(escape.escape_chars_map.get(c, c) for c in item)
 
     elif isinstance(item, list):
-        return "[%s]" % ",".join(
-            str(escape_param(x, context, for_server=for_server)) for x in item
-        )
+        return "[%s]" % ",".join(str(escape_param(x, context)) for x in item)
 
     elif isinstance(item, tuple):
-        return "tuple(%s)" % ",".join(
-            str(escape_param(x, context, for_server=for_server)) for x in item
-        )
+        return "tuple(%s)" % ",".join(str(escape_param(x, context)) for x in item)
 
     elif isinstance(item, dict):
         return "map(%s)" % ",".join(
-            str(escape_param(x, context, for_server=for_server))
-            for x in chain.from_iterable(item.items())
+            str(escape_param(x, context)) for x in chain.from_iterable(item.items())
         )
 
     elif isinstance(item, Enum):
-        return escape_param(item.value, context, for_server=for_server)
+        return escape_param(item.value, context)
 
     elif isinstance(item, (UUID, IPv4Address, IPv6Address)):
         return "'%s'" % str(item)
@@ -86,35 +77,24 @@ def escape_param(item, context, for_server=False):
     elif isinstance(item, types.JSON):
         value = item.value
         if isinstance(value, list):
-            return escape_param(
-                [types.JSON(v) for v in value], context, for_server=for_server
-            )
+            return escape_param([types.JSON(v) for v in value], context)
         elif isinstance(value, dict):
-            return escape_param(
-                tuple(types.JSON(v) for v in value.values()),
-                context,
-                for_server=for_server,
-            )
+            return escape_param(tuple(types.JSON(v) for v in value.values()), context)
         else:
-            return escape_param(value, context, for_server=for_server)
+            return escape_param(value, context)
 
     else:
         return item
 
 
-def escape_params(params: Params, context: Dict, for_server=False) -> Params:
+def escape_params(params: Params, context: Dict) -> Params:
     """Escape param to qualified string representation.
 
     This function is not used in INSERT INTO queries.
     """
     if isinstance(params, dict):
-        escaped = {
-            key: escape_param(value, context, for_server=for_server)
-            for key, value in params.items()
-        }
+        escaped = {key: escape_param(value, context) for key, value in params.items()}
     else:
-        escaped = tuple(
-            escape_param(value, context, for_server=for_server) for value in params
-        )
+        escaped = tuple(escape_param(value, context) for value in params)
 
     return escaped


### PR DESCRIPTION
Follow-up to #180, as noted there.

`clickhouse_backend/driver/connection.py` replaced `clickhouse_driver.connection.Connection.send_query` at import time. It was added for #14: clickhouse-driver 0.2.6 escaped query parameters and sent them as custom settings unconditionally, which crashes on the list parameters django passes (`escape_params()` requires a mapping). Upstream added the same `server_side_params` guard in **0.2.7**, and this project has pinned 0.2.8 or newer ever since.

Diffing our copy against 0.2.11's original leaves exactly one semantic difference: which `escape_params()` it calls. And that difference only applies when `server_side_params=True`, which:

- the backend never sets — clickhouse-driver defaults it to `False`;
- the ORM cannot use at all, because django emits `%s` placeholders while ClickHouse server side parameters need `{name:Type}` syntax. Turning it on raises `AttributeError: 'tuple' object has no attribute 'items'` on the first parameterised query, with or without this patch.

So the patch changed nothing for this backend. What it did do, being a module level assignment, is take upstream's escaping away from any code that uses clickhouse-driver directly in the same process — including 0.2.11's fix for list and tuple parameters. Against a live server, with the patch in place a plain `Client(settings={"server_side_params": True})` fails:

```
select {x:Array(Int32)}, {"x": [1, 2]}  ->  Code: 27. DB::ParsingException:
    value [ cannot be parsed as Array(Int32) for query parameter 'x'
```

because our `escape_param()` recursed with `for_server=for_server` while decorated with `maybe_enquote_for_server`, quoting at every level: `'['1','2']'` instead of `'[1, 2]'`. With the patch removed it returns `[([1, 2],)]`.

`escape_param()` and `escape_params()` lose their `for_server` argument, which now has no caller. The two remaining callers, `backend/schema.py` and `driver/client.py`, already pass two positional arguments.

Verified: the ORM path is untouched (`select %s, %s, %s` with `[[1, 2], (1, 2), "a'b"]` still round trips through our escaping), and the full suite passes against a local cluster — `Ran 1081 tests in 254s — OK (skipped=8)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
