### PR TITLE
fix: Escape function causing inconsistent zero-padding behaviour

### DIFF
--- a/clickhouse_backend/driver/escape.py
+++ b/clickhouse_backend/driver/escape.py
@@ -22,11 +22,8 @@ def escape_datetime(item: datetime, context):
     if item.tzinfo is None:
         return item.timestamp()
 
-    item = item.astimezone(timezone.utc)
-    if item.microsecond == 0:
-        return "'%s'" % item.strftime("%Y-%m-%d %H:%M:%S")
-    else:
-        return "'%s'" % item.strftime("%Y-%m-%d %H:%M:%S.%f")
+    item = item.astimezone(timezone.utc).replace(tzinfo=None)
+    return "'%s'" % item.isoformat(sep=" ")
 
 
 def escape_binary(item: bytes, context):

--- a/tests/backends/clickhouse/test_escape.py
+++ b/tests/backends/clickhouse/test_escape.py
@@ -23,6 +23,12 @@ class EscapeParamTests(SimpleTestCase):
             escape_param(aware.replace(microsecond=0), {}), "'2024-01-02 03:04:05'"
         )
 
+    def test_datetime_aware_non_utc(self):
+        tz = datetime.timezone(datetime.timedelta(hours=5))
+        aware = datetime.datetime(2024, 1, 2, 3, 4, 5, 678901, tzinfo=tz)
+        # 2024-01-02 03:04:05+05:00 == 2024-01-01 22:04:05 UTC
+        self.assertEqual(escape_param(aware, {}), "'2024-01-01 22:04:05.678901'")
+
     def test_collections(self):
         self.assertEqual(escape_param([1, "a"], {}), "[1,'a']")
         # A one element tuple is tuple(x), clickhouse-driver renders (x), which


### PR DESCRIPTION
**⚠️ Feedback needed:**
I'm not sure if this breaks any existing behaviour or if there are edge cases I'm not considering.

The Python `strftime()` function causes inconsistent zero-padding behaviour with dates < the year 1000 depending on platform.

MacOs
```
d  = datetime(9, 1, 1)
d.strftime("%Y-%m-%d %H:%M:%S.%f")
'0009-01-01 00:00:00.000000'
```

vs Linux
```
d  = datetime(9, 1, 1)
d.strftime("%Y-%m-%d %H:%M:%S.%f")
'9-01-01 00:00:00.000000'
```

Depending on platform, the `escape_datetime` function causes the earliest possible dates to be zero-padded incorrectly 
```
from datetime import timezone, datetime
from clickhouse_backend.driver.escape import escape_datetime

d = datetime(9, 1, 1, tzinfo=timezone.utc)
escape_datetime(d, {})
"'9-01-01 00:00:00'"
```
This then leads to dates being passed through to Clickhouse that it cannot handle `DB::Exception: Cannot parse DateTime: while converting '9-01-01 00:00:00' to DateTime64(6, 'UTC')`

This PR changes `escape_datetime()` to use `.isoformat` which consistently zero-pads the year regardless of platform.
```
from datetime import timezone, datetime
from clickhouse_backend.driver.escape import escape_datetime

d = datetime(9, 1, 1, tzinfo=timezone.utc)
escape_datetime(d, {})
"'0009-01-01 00:00:00'"
```